### PR TITLE
chore: Defined changelog_file for prepare-release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,4 +21,5 @@ jobs:
     with:
       release_type: ${{ github.event.inputs.release_type }}
       use_new_release: ${{ vars.USE_NEW_RELEASE }}
+      changelog_file: CHANGELOG.md
 


### PR DESCRIPTION
## Description

Defined changelog_file for prepare-release.yml. 

## Details
This workflow did not specify changelog_file, so the prepare-release workflow failed: it defaults to NEWS.md, which does not exist in this repo. 