### PR TITLE
chore: update workflow file to get latest run before releasing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,6 @@ jobs:
     uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
     with:
       changelog_file: CHANGELOG.md
+      workflows: ci.yml
     secrets:
       npm_token: ${{ secrets.NODE_AGENT_NPM_TOKEN }}


### PR DESCRIPTION
We have never run the create release and it [failed](https://github.com/newrelic/newrelic-introspector-node/actions/runs/6001847231/job/16276926900).  I triaged locally and it was because it was looking for a ci file called `ci-workflow.yml`.  This repo's CI file is called `ci.yml`.
