### PR TITLE
feat: Introspect node version from `pm2` env

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -38,7 +38,8 @@ const introspect = async (argv) => {
       pm_id: proc.pm_id,
       name: proc.name,
       pm_exec_path: proc.pm2_env.pm_exec_path,
-      pm_cwd: proc.pm2_env.pm_cwd
+      pm_cwd: proc.pm2_env.pm_cwd,
+      node_version: proc.pm2_env.node_version
     }
 
     console.log(JSON.stringify(output))

--- a/test/unit/commands.test.js
+++ b/test/unit/commands.test.js
@@ -90,7 +90,8 @@ tap.test('commands', (t) => {
       name: 'Unit Test',
       pm2_env: {
         pm_exec_path: '/path/to/pm2',
-        pm_cwd: 'pm2 list'
+        pm_cwd: 'pm2 list',
+        node_version: '16.20.2'
       }
     }
 
@@ -104,7 +105,8 @@ tap.test('commands', (t) => {
         pm_id: 1,
         name: 'Unit Test',
         pm_exec_path: '/path/to/pm2',
-        pm_cwd: 'pm2 list'
+        pm_cwd: 'pm2 list',
+        node_version: '16.20.2'
       }),
       'should list meta about a pid'
     )


### PR DESCRIPTION
## Description

Enhances the `instrospect` command to output the node version. 

## How to Test

1. On a Linux EC2 instance, ran a node app ([nodetron](https://www.npmjs.com/package/nodetron)) using node v16.20.2 via pm2. 
2. Ran `newrelic-introspector-node list` to get the process id.
3. Ran `newrelic-introspector-node introspect --pid <PROCESS_ID>`
4. Observed the node version in the output:

```json
{
  "pid": 27905,
  "pm_id": 0,
  "name": "npm",
  "pm_exec_path": "/home/ec2-user/.nvm/versions/node/v16.20.2/bin/npm",
  "pm_cwd": "/home/ec2-user/nodetron",
  "node_version": "16.20.2"
}
```

## Related Issues

NR-174922 - add a minimum node version check to the [Node.js `open-install-library` recipe](https://github.com/newrelic/open-install-library/blob/main/recipes/newrelic/apm/node/linux.yml)