### PR TITLE
test: Migrated the tests from `tap` to `node:test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint src/*.js test/**/*.js",
     "lint:fix": "eslint --fix src/*.js test/**/*.js",
-    "unit": "c8 tap test/unit/*.test.js --no-coverage",
+    "unit": "c8 -o ./coverage/unit node --test test/unit/*.test.js",
     "prepare": "husky install",
     "test": "npm run unit"
   },
@@ -30,8 +30,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "lockfile-lint": "^4.9.6",
-    "sinon": "^10.0.0",
-    "tap": "^16.3.7"
+    "sinon": "^10.0.0"
   },
   "files": [
     "LICENSE",

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -5,7 +5,8 @@
 
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
+const assert = require('node:assert')
 const cp = require('child_process')
 const util = require('util')
 const execAsync = util.promisify(cp.exec)
@@ -16,50 +17,42 @@ const execAsync = util.promisify(cp.exec)
  * of the actual commands that is done elsewhere
  */
 
-tap.test('cli', (t) => {
-  t.autoend()
+test('should run list', async () => {
+  await assert.rejects(
+    execAsync('node ./src/cli list'),
+    /Command failed: pm2 jlist/,
+    'should run and fail because pm2 is not installed'
+  )
+})
 
-  t.test('should run list', async (t) => {
-    t.rejects(
-      execAsync('node ./src/cli list'),
-      /Command failed: pm2 jlist/,
-      'should run and fail because pm2 is not installed'
-    )
-    t.end()
-  })
-  t.test('should error if pid is not provided when calling introspect', async (t) => {
-    t.rejects(
-      execAsync('node ./src/cli introspect'),
-      /Missing required argument: pid/,
-      'should state pid is required'
-    )
-    t.end()
-  })
+test('should error if pid is not provided when calling introspect', async () => {
+  await assert.rejects(
+    execAsync('node ./src/cli introspect'),
+    /Missing required argument: pid/,
+    'should state pid is required'
+  )
+})
 
-  t.test('should run introspect when pid is provided', async (t) => {
-    t.rejects(
-      execAsync('node ./src/cli introspect --pid 0'),
-      /Command failed: pm2 jlist/,
-      'should run and fail because pm2 is not installed'
-    )
-    t.end()
-  })
+test('should run introspect when pid is provided', async () => {
+  await assert.rejects(
+    execAsync('node ./src/cli introspect --pid 0'),
+    /Command failed: pm2 jlist/,
+    'should run and fail because pm2 is not installed'
+  )
+})
 
-  t.test('should error when required fields are missing with instrument', async (t) => {
-    t.rejects(
-      execAsync('node ./src/cli instrument'),
-      /Missing required arguments: pid, licenseKey/,
-      'should state pid is required'
-    )
-    t.end()
-  })
+test('should error when required fields are missing with instrument', async () => {
+  await assert.rejects(
+    execAsync('node ./src/cli instrument'),
+    /Missing required arguments: pid, licenseKey/,
+    'should state pid is required'
+  )
+})
 
-  t.test('should run instrument', async (t) => {
-    t.rejects(
-      execAsync('node ./src/cli instrument --pid 0 --licenseKey super-secret --appName test'),
-      /Command failed: pm2 jlist/,
-      'should run and fail because pm2 is not installed'
-    )
-    t.end()
-  })
+test('should run instrument', async () => {
+  await assert.rejects(
+    execAsync('node ./src/cli instrument --pid 0 --licenseKey super-secret --appName test'),
+    /Command failed: pm2 jlist/,
+    'should run and fail because pm2 is not installed'
+  )
 })

--- a/test/unit/commands.test.js
+++ b/test/unit/commands.test.js
@@ -6,192 +6,195 @@
 /* eslint-disable no-console */
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
+const assert = require('node:assert')
 const utils = require('../../src/utils')
 const sinon = require('sinon')
 
-tap.test('commands', (t) => {
-  let sandbox
-  let list
-  let introspect
-  let instrument
+test.beforeEach((ctx) => {
+  const sandbox = sinon.createSandbox()
+  sandbox.stub(console, 'log')
+  sandbox.stub(console, 'error')
+  sandbox.stub(process, 'exit')
+  sandbox.stub(utils, 'pm2List')
+  sandbox.stub(utils, 'getProc')
+  sandbox.stub(utils, 'getTruePath')
+  sandbox.stub(utils, 'pm2RestartandSave')
+  sandbox.stub(utils, 'exec')
+  const { list, introspect, instrument } = require('../../src/commands')
+  ctx.nr = { sandbox, list, introspect, instrument }
+})
 
-  t.autoend()
+test.afterEach((ctx) => {
+  ctx.nr.sandbox.restore()
+  // clean up so stubs do not persist
+  delete require.cache[require.resolve('../../src/commands')]
+})
 
-  t.beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    sandbox.stub(console, 'log')
-    sandbox.stub(console, 'error')
-    sandbox.stub(process, 'exit')
-    sandbox.stub(utils, 'pm2List')
-    sandbox.stub(utils, 'getProc')
-    sandbox.stub(utils, 'getTruePath')
-    sandbox.stub(utils, 'pm2RestartandSave')
-    sandbox.stub(utils, 'exec')
-    ;({ list, introspect, instrument } = require('../../src/commands'))
-  })
-
-  t.afterEach(() => {
-    sandbox.restore()
-    // clean up so stubs do not persist
-    delete require.cache[require.resolve('../../src/commands')]
-  })
-
-  t.test('list should list all pm2 online pids', async (t) => {
-    const processes = [
-      {
-        pid: 0,
-        pm2_env: {
-          status: 'online'
-        }
-      },
-      {
-        pid: 1,
-        pm2_env: {
-          status: 'stopped'
-        }
-      },
-      {
-        pid: 2,
-        pm2_env: {
-          status: 'online'
-        }
+test('list should list all pm2 online pids', async (t) => {
+  const { list } = t.nr
+  const processes = [
+    {
+      pid: 0,
+      pm2_env: {
+        status: 'online'
       }
-    ]
+    },
+    {
+      pid: 1,
+      pm2_env: {
+        status: 'stopped'
+      }
+    },
+    {
+      pid: 2,
+      pm2_env: {
+        status: 'online'
+      }
+    }
+  ]
 
-    utils.pm2List.resolves(processes)
-    await list()
-    t.same(console.log.args[0][0], [0, 2], 'should only list pids online')
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
-  })
+  utils.pm2List.resolves(processes)
+  await list()
+  assert.deepEqual(console.log.args[0][0], [0, 2], 'should only list pids online')
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
+})
 
-  t.test('should list 0 pids if no pm2 processes exist', async (t) => {
-    utils.pm2List.resolves([])
-    await list()
-    t.same(console.log.args[0][0], [], 'should not list any pids')
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
-  })
+test('should list 0 pids if no pm2 processes exist', async (t) => {
+  const { list } = t.nr
+  utils.pm2List.resolves([])
+  await list()
+  assert.deepEqual(console.log.args[0][0], [], 'should not list any pids')
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
+})
 
-  t.test('should log console error when pm2List fails', async (t) => {
-    const err = new Error('failed to list pids')
-    utils.pm2List.rejects(err)
-    await list()
-    t.same(console.error.args[0][0], err, 'should log error')
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
-  })
+test('should log console error when pm2List fails', async (t) => {
+  const { list } = t.nr
+  const err = new Error('failed to list pids')
+  utils.pm2List.rejects(err)
+  await list()
+  assert.deepEqual(console.error.args[0][0], err, 'should log error')
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
+})
 
-  t.test('introspect should list pm2 metadata in json format', async (t) => {
-    const pm2Meta = {
+test('introspect should list pm2 metadata in json format', async (t) => {
+  const { introspect } = t.nr
+  const pm2Meta = {
+    pid: 0,
+    pm_id: 1,
+    name: 'Unit Test',
+    pm2_env: {
+      pm_exec_path: '/path/to/pm2',
+      pm_cwd: 'pm2 list',
+      node_version: '16.20.2'
+    }
+  }
+
+  utils.getProc.resolves(pm2Meta)
+
+  await introspect({ pid: 0 })
+  assert.equal(
+    console.log.args[0][0],
+    JSON.stringify({
       pid: 0,
       pm_id: 1,
       name: 'Unit Test',
-      pm2_env: {
-        pm_exec_path: '/path/to/pm2',
-        pm_cwd: 'pm2 list',
-        node_version: '16.20.2'
-      }
-    }
-
-    utils.getProc.resolves(pm2Meta)
-
-    await introspect({ pid: 0 })
-    t.equal(
-      console.log.args[0][0],
-      JSON.stringify({
-        pid: 0,
-        pm_id: 1,
-        name: 'Unit Test',
-        pm_exec_path: '/path/to/pm2',
-        pm_cwd: 'pm2 list',
-        node_version: '16.20.2'
-      }),
-      'should list meta about a pid'
-    )
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
-  })
-
-  t.test('introspect should log error when getProc fails', async (t) => {
-    const err = new Error('failed to get pid meta')
-    utils.getProc.rejects(err)
-    await introspect({})
-    t.same(console.error.args[0][0], err, 'should log error')
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
-  })
-
-  t.test('instrument should install agent and restart pm2 with agent loaded', async (t) => {
-    const pidMeta = { pm_id: 0 }
-    utils.getProc.resolves(pidMeta)
-    const truePath = '/path/for/realz'
-    utils.getTruePath.resolves(truePath)
-    utils.pm2RestartandSave.resolves()
-    const output = {
-      stderr: 'no error',
-      stdout: 'install done!'
-    }
-    utils.exec.resolves(output)
-
-    await instrument({ pid: 0 })
-    t.same(console.error.callCount, 3, 'should call console.error three times')
-    t.equal(console.error.args[0][0], output.stdout, 'should log stdout')
-    t.equal(console.error.args[1][0], output.stderr, 'should log stderr')
-    t.equal(console.error.args[2][0], 'Process instrumented successfully')
-    t.equal(utils.exec.args[0][1], truePath, 'should install with truePath')
-    t.equal(utils.pm2RestartandSave.args[0][0], 0, 'should call restart with the appropriate pid')
-    t.equal(process.exit.callCount, 1, 'should exit once')
-    t.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
-  })
-
-  t.test('should set process env vars from argv', async (t) => {
-    utils.getProc.resolves({})
-    utils.getTruePath.resolves()
-    utils.exec.resolves({})
-    utils.pm2RestartandSave.resolves()
-
-    const argv = {
-      pid: 0,
-      licenseKey: 'super-secret',
-      appName: 'my-app',
-      region: 'prod'
-    }
-
-    await instrument(argv)
-    t.equal(process.env.NEW_RELIC_LICENSE_KEY, argv.licenseKey)
-    t.equal(process.env.NEW_RELIC_APP_NAME, argv.appName)
-    t.equal(process.env.NEW_RELIC_HOST, undefined)
-    t.equal(process.env.NEW_RELIC_DISTRIBUTED_TRACING_ENABLED, 'true')
-  })
-
-  t.test('should set NEW_RELIC_HOST to staging url if region is staging', async (t) => {
-    utils.getProc.resolves({ name: 'test-app' })
-    utils.getTruePath.resolves()
-    utils.exec.resolves({})
-    utils.pm2RestartandSave.resolves()
-
-    const argv = {
-      pid: 0,
-      licenseKey: 'super-secret',
-      region: 'staging'
-    }
-
-    await instrument(argv)
-    t.equal(process.env.NEW_RELIC_HOST, 'staging-collector.newrelic.com')
-    t.equal(process.env.NEW_RELIC_APP_NAME, 'test-app')
-  })
-
-  t.test(
-    'should log error and exit with code 0 if any async function fails in instrument',
-    async (t) => {
-      const err = new Error('failed to get pid meta')
-      utils.getProc.rejects(err)
-      await instrument({})
-      t.same(console.error.args[0][0], err, 'should log error')
-      t.equal(process.exit.callCount, 1, 'should exit once')
-      t.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
-    }
+      pm_exec_path: '/path/to/pm2',
+      pm_cwd: 'pm2 list',
+      node_version: '16.20.2'
+    }),
+    'should list meta about a pid'
   )
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
+})
+
+test('introspect should log error when getProc fails', async (t) => {
+  const { introspect } = t.nr
+  const err = new Error('failed to get pid meta')
+  utils.getProc.rejects(err)
+  await introspect({})
+  assert.deepEqual(console.error.args[0][0], err, 'should log error')
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
+})
+
+test('instrument should install agent and restart pm2 with agent loaded', async (t) => {
+  const { instrument } = t.nr
+  const pidMeta = { pm_id: 0 }
+  utils.getProc.resolves(pidMeta)
+  const truePath = '/path/for/realz'
+  utils.getTruePath.resolves(truePath)
+  utils.pm2RestartandSave.resolves()
+  const output = {
+    stderr: 'no error',
+    stdout: 'install done!'
+  }
+  utils.exec.resolves(output)
+
+  await instrument({ pid: 0 })
+  assert.deepEqual(console.error.callCount, 3, 'should call console.error three times')
+  assert.equal(console.error.args[0][0], output.stdout, 'should log stdout')
+  assert.equal(console.error.args[1][0], output.stderr, 'should log stderr')
+  assert.equal(console.error.args[2][0], 'Process instrumented successfully')
+  assert.equal(utils.exec.args[0][1], truePath, 'should install with truePath')
+  assert.equal(
+    utils.pm2RestartandSave.args[0][0],
+    0,
+    'should call restart with the appropriate pid'
+  )
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 0, 'should called process exit with code 0')
+})
+
+test('should set process env vars from argv', async (t) => {
+  const { instrument } = t.nr
+  utils.getProc.resolves({})
+  utils.getTruePath.resolves()
+  utils.exec.resolves({})
+  utils.pm2RestartandSave.resolves()
+
+  const argv = {
+    pid: 0,
+    licenseKey: 'super-secret',
+    appName: 'my-app',
+    region: 'prod'
+  }
+
+  await instrument(argv)
+  assert.equal(process.env.NEW_RELIC_LICENSE_KEY, argv.licenseKey)
+  assert.equal(process.env.NEW_RELIC_APP_NAME, argv.appName)
+  assert.equal(process.env.NEW_RELIC_HOST, undefined)
+  assert.equal(process.env.NEW_RELIC_DISTRIBUTED_TRACING_ENABLED, 'true')
+})
+
+test('should set NEW_RELIC_HOST to staging url if region is staging', async (t) => {
+  const { instrument } = t.nr
+  utils.getProc.resolves({ name: 'test-app' })
+  utils.getTruePath.resolves()
+  utils.exec.resolves({})
+  utils.pm2RestartandSave.resolves()
+
+  const argv = {
+    pid: 0,
+    licenseKey: 'super-secret',
+    region: 'staging'
+  }
+
+  await instrument(argv)
+  assert.equal(process.env.NEW_RELIC_HOST, 'staging-collector.newrelic.com')
+  assert.equal(process.env.NEW_RELIC_APP_NAME, 'test-app')
+})
+
+test('should log error and exit with code 0 if any async function fails in instrument', async (t) => {
+  const { instrument } = t.nr
+  const err = new Error('failed to get pid meta')
+  utils.getProc.rejects(err)
+  await instrument({})
+  assert.deepEqual(console.error.args[0][0], err, 'should log error')
+  assert.equal(process.exit.callCount, 1, 'should exit once')
+  assert.equal(process.exit.args[0][0], 1, 'should called process exit with code 1')
 })

--- a/test/unit/execAsPromise.test.js
+++ b/test/unit/execAsPromise.test.js
@@ -5,47 +5,45 @@
 
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
+const assert = require('node:assert')
 const cp = require('child_process')
 const { execPromise } = require('../../src/execPromise')
 const sinon = require('sinon')
 
-tap.test('execPromise', (t) => {
-  let execStub
+test.beforeEach((ctx) => {
+  ctx.nr = { execStub: sinon.stub(cp, 'exec') }
+})
 
-  t.autoend()
+test.afterEach((ctx) => {
+  ctx.nr.execStub.restore()
+})
 
-  t.beforeEach(() => {
-    execStub = sinon.stub(cp, 'exec')
-  })
+test('should resolve exec with stdout and stderr', async (t) => {
+  const { execStub } = t.nr
+  const stdout = 'done!'
+  const stderr = 'failed?'
+  const cmd = 'my cmd'
+  execStub.yields(null, stdout, stderr)
+  const results = await execPromise(cmd)
+  assert.deepEqual(results, { stdout, stderr }, 'should return with stdout and stderr')
+  assert.equal(execStub.args[0][0], cmd)
+})
 
-  t.afterEach(() => {
-    execStub.restore()
-  })
+test('should set cwd if pass in as 2nd arg', async (t) => {
+  const { execStub } = t.nr
+  const stdout = 'done!'
+  const stderr = 'failed?'
+  const cmd = 'my cmd'
+  const cwd = '/path/to/my-cwd'
+  execStub.yields(null, stdout, stderr)
+  await execPromise(cmd, cwd)
+  assert.deepEqual(execStub.args[0][1], { cwd })
+})
 
-  t.test('should resolve exec with stdout and stderr', async (t) => {
-    const stdout = 'done!'
-    const stderr = 'failed?'
-    const cmd = 'my cmd'
-    execStub.yields(null, stdout, stderr)
-    const results = await execPromise(cmd)
-    t.same(results, { stdout, stderr }, 'should return with stdout and stderr')
-    t.equal(execStub.args[0][0], cmd)
-  })
-
-  t.test('should set cwd if pass in as 2nd arg', async (t) => {
-    const stdout = 'done!'
-    const stderr = 'failed?'
-    const cmd = 'my cmd'
-    const cwd = '/path/to/my-cwd'
-    execStub.yields(null, stdout, stderr)
-    await execPromise(cmd, cwd)
-    t.same(execStub.args[0][1], { cwd })
-  })
-
-  t.test('should reject with error when exec fails', async (t) => {
-    const err = new Error('failed to exec cmd')
-    execStub.yields(err)
-    t.rejects(execPromise(), err, 'rejected with proper error')
-  })
+test('should reject with error when exec fails', async (t) => {
+  const { execStub } = t.nr
+  const err = new Error('failed to exec cmd')
+  execStub.yields(err)
+  await assert.rejects(execPromise(), err, 'rejected with proper error')
 })

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -5,86 +5,76 @@
 
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
+const assert = require('node:assert')
 const execPromise = require('../../src/execPromise')
 const sinon = require('sinon')
 
 const { getProc, pm2RestartandSave } = require('../../src/utils')
 
-tap.test('utils', (test) => {
-  let execStub
+test.beforeEach((ctx) => {
+  ctx.nr = { execStub: sinon.stub(execPromise, 'execPromise') }
+})
 
-  test.autoend()
+test.afterEach((ctx) => {
+  ctx.nr.execStub.restore()
+})
 
-  test.beforeEach(() => {
-    execStub = sinon.stub(execPromise, 'execPromise')
-  })
-
-  test.afterEach(() => {
-    execStub.restore()
-  })
-
-  test.test('getProc returns running node app info', async (t) => {
-    const stdout = [
-      {
-        pid: 0
-      }
-    ]
-
-    const processObject = {
-      stdout: JSON.stringify(stdout),
-      stderr: ''
+test('getProc returns running node app info', async (t) => {
+  const { execStub } = t.nr
+  const stdout = [
+    {
+      pid: 0
     }
-    execStub.returns(Promise.resolve(processObject))
-    const result = await getProc(0)
+  ]
 
-    t.equal(result.pid, 0)
+  const processObject = {
+    stdout: JSON.stringify(stdout),
+    stderr: ''
+  }
+  execStub.returns(Promise.resolve(processObject))
+  const result = await getProc(0)
 
-    t.end()
-  })
+  assert.equal(result.pid, 0)
+})
 
-  test.test('getProc should throw when pid not found', async (t) => {
-    const stdout = []
+test('getProc should throw when pid not found', async (t) => {
+  const { execStub } = t.nr
+  const stdout = []
 
-    const processObject = {
-      stdout: JSON.stringify(stdout),
-      stderr: ''
-    }
-    execStub.returns(Promise.resolve(processObject))
+  const processObject = {
+    stdout: JSON.stringify(stdout),
+    stderr: ''
+  }
+  execStub.returns(Promise.resolve(processObject))
 
-    try {
-      await getProc(0)
-    } catch (err) {
-      t.ok(err, 'throws when pid not found')
-    }
+  await assert.rejects(getProc(0), 'throws when pid not found')
+})
 
-    t.end()
-  })
+test('pm2RestartAndSave should restart and save in pm2', async (t) => {
+  const { execStub } = t.nr
+  execStub.resolves()
+  await pm2RestartandSave(1)
+  assert.equal(execStub.callCount, 2, 'should call restart and save')
+  assert.equal(
+    execStub.args[0][0],
+    'pm2 restart 1 --update-env --node-args "-r newrelic"',
+    'should call restart with proper args'
+  )
+  assert.equal(execStub.args[1][0], 'pm2 save', 'should call save')
+})
 
-  test.test('pm2RestartAndSave should restart and save in pm2', async (t) => {
-    execStub.resolves()
-    await pm2RestartandSave(1)
-    t.equal(execStub.callCount, 2, 'should call restart and save')
-    t.equal(
-      execStub.args[0][0],
-      'pm2 restart 1 --update-env --node-args "-r newrelic"',
-      'should call restart with proper args'
-    )
-    t.equal(execStub.args[1][0], 'pm2 save', 'should call save')
-  })
+test('pm2RestartAndSave should throw error if restart fails', async (t) => {
+  const { execStub } = t.nr
+  const err = new Error('restart failed')
+  execStub.onCall(0).rejects(err)
+  await assert.rejects(pm2RestartandSave(1), err, 'should reject with restart error')
+})
 
-  test.test('pm2RestartAndSave should throw error if restart fails', (t) => {
-    const err = new Error('restart failed')
-    execStub.onCall(0).rejects(err)
-    t.rejects(pm2RestartandSave(1), err, 'should reject with restart error')
-    t.end()
-  })
-
-  test.test('pm2RestartAndSave should throw error if save fails', async (t) => {
-    const err = new Error('save failed')
-    execStub.onCall(0).resolves()
-    execStub.onCall(1).rejects(err)
-    t.rejects(pm2RestartandSave(1), err, 'should reject with save error')
-    t.end()
-  })
+test('pm2RestartAndSave should throw error if save fails', async (t) => {
+  const { execStub } = t.nr
+  const err = new Error('save failed')
+  execStub.onCall(0).resolves()
+  execStub.onCall(1).rejects(err)
+  await assert.rejects(pm2RestartandSave(1), err, 'should reject with save error')
 })

--- a/test/unit/utilsPath.test.js
+++ b/test/unit/utilsPath.test.js
@@ -5,217 +5,191 @@
 
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
+const assert = require('node:assert')
 const { checkPackageJson, getTruePath } = require('../../src/utils')
 
 const fs = require('fs')
 const sinon = require('sinon')
 
-tap.test('helper', (test) => {
-  let statSyncStub
+test.beforeEach((ctx) => {
+  ctx.nr = { statSyncStub: sinon.stub(fs, 'statSync') }
+})
 
-  test.autoend()
+test.afterEach((ctx) => {
+  ctx.nr.statSyncStub.restore()
+})
 
-  test.beforeEach(() => {
-    statSyncStub = sinon.stub(fs, 'statSync')
+test('checkPackageJson returns true if path is dir with package.json', (t) => {
+  const { statSyncStub } = t.nr
+  const pathToCheck = '/dir'
+  const pathPkgJson = '/dir/package.json'
+
+  statSyncStub.withArgs(pathToCheck).returns({
+    isFile: () => false
   })
-
-  test.afterEach(() => {
-    statSyncStub.restore()
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => true
   })
+  const result = checkPackageJson(pathToCheck)
 
-  test.test('checkPackageJson returns true if path is dir with package.json', (t) => {
-    const pathToCheck = '/dir'
-    const pathPkgJson = '/dir/package.json'
+  assert.ok(result)
+})
 
-    statSyncStub.withArgs(pathToCheck).returns({
-      isFile: () => false
-    })
-    statSyncStub.withArgs(pathPkgJson).returns({
-      isFile: () => true
-    })
-    const result = checkPackageJson(pathToCheck)
+test('checkPackageJson returns true if false is dir with no package.json', (t) => {
+  const { statSyncStub } = t.nr
+  const pathToCheck = '/dir'
+  const pathPkgJson = '/dir/package.json'
 
-    t.ok(result)
-
-    t.end()
+  statSyncStub.withArgs(pathToCheck).returns({
+    isFile: () => false
   })
-
-  test.test('checkPackageJson returns true if false is dir with no package.json', (t) => {
-    const pathToCheck = '/dir'
-    const pathPkgJson = '/dir/package.json'
-
-    statSyncStub.withArgs(pathToCheck).returns({
-      isFile: () => false
-    })
-    statSyncStub.withArgs(pathPkgJson).returns({
-      isFile: () => false
-    })
-    const result = checkPackageJson(pathToCheck)
-
-    t.notOk(result)
-
-    t.end()
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => false
   })
+  const result = checkPackageJson(pathToCheck)
 
-  test.test(
-    "checkPackageJson returns true if path is dir, path ends in '/', with package.json",
-    (t) => {
-      const pathToCheck = '/dir/'
-      const pathPkgJson = '/dir/package.json'
+  assert.ok(!result)
+})
 
-      statSyncStub.withArgs(pathToCheck).returns({
-        isFile: () => false
-      })
-      statSyncStub.withArgs(pathPkgJson).returns({
-        isFile: () => true
-      })
-      const result = checkPackageJson(pathToCheck)
+test("checkPackageJson returns true if path is dir, path ends in '/', with package.json", (t) => {
+  const { statSyncStub } = t.nr
+  const pathToCheck = '/dir/'
+  const pathPkgJson = '/dir/package.json'
 
-      t.ok(result)
+  statSyncStub.withArgs(pathToCheck).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => true
+  })
+  const result = checkPackageJson(pathToCheck)
 
-      t.end()
+  assert.ok(result)
+})
+
+test('checkPackageJson returns true if path is file with package.json in dir', (t) => {
+  const { statSyncStub } = t.nr
+  const pathToCheck = '/dir/file.js'
+  const pathPkgJson = '/dir/package.json'
+
+  statSyncStub.withArgs(pathToCheck).returns({
+    isFile: () => true
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => true
+  })
+  const result = checkPackageJson(pathToCheck)
+
+  assert.ok(result)
+})
+
+test('checkPackageJson returns true if path is file with no package.json in dir', (t) => {
+  const { statSyncStub } = t.nr
+  const pathToCheck = '/dir/file.js'
+  const pathPkgJson = '/dir/package.json'
+
+  statSyncStub.withArgs(pathToCheck).returns({
+    isFile: () => true
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => false
+  })
+  const result = checkPackageJson(pathToCheck)
+
+  assert.ok(!result)
+})
+
+test('getTruePath returns pm_cwd path if its good and removes filename from path', async (t) => {
+  const { statSyncStub } = t.nr
+  const pmCwdPath = '/dir/file.js'
+  const pathPkgJson = '/dir/package.json'
+  const pmExecPath = '/otherdir'
+  const pathExecPkgJson = '/otherdir/package.json'
+
+  const process = {
+    pm2_env: {
+      pm_cwd: pmCwdPath,
+      pm_exec_path: pmExecPath
     }
-  )
+  }
 
-  test.test('checkPackageJson returns true if path is file with package.json in dir', (t) => {
-    const pathToCheck = '/dir/file.js'
-    const pathPkgJson = '/dir/package.json'
+  statSyncStub.withArgs(pmCwdPath).returns({
+    isFile: () => true
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => true
+  })
+  statSyncStub.withArgs(pmExecPath).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathExecPkgJson).returns({
+    isFile: () => false
+  })
+  const result = await getTruePath(process)
 
-    statSyncStub.withArgs(pathToCheck).returns({
-      isFile: () => true
-    })
-    statSyncStub.withArgs(pathPkgJson).returns({
-      isFile: () => true
-    })
-    const result = checkPackageJson(pathToCheck)
+  assert.ok(result)
+  assert.equal(result, '/dir')
+})
 
-    t.ok(result)
+test('getTruePath returns pm_exec_path is dir w/ package.json and pm_cwd is bad', async (t) => {
+  const { statSyncStub } = t.nr
+  const pmCwdPath = '/dir'
+  const pathPkgJson = '/dir/package.json'
+  const pmExecPath = '/otherdir'
+  const pathExecPkgJson = '/otherdir/package.json'
 
-    t.end()
+  const process = {
+    pm2_env: {
+      pm_cwd: pmCwdPath,
+      pm_exec_path: pmExecPath
+    }
+  }
+
+  statSyncStub.withArgs(pmCwdPath).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pmExecPath).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathExecPkgJson).returns({
+    isFile: () => true
+  })
+  const result = await getTruePath(process)
+
+  assert.ok(result)
+  assert.equal(result, '/otherdir')
+})
+
+test('getTruePath rejects when pm_exec_path and pm_cwd are bad', async (t) => {
+  const { statSyncStub } = t.nr
+  const pmCwdPath = '/dir'
+  const pathPkgJson = '/dir/package.json'
+  const pmExecPath = '/otherdir'
+  const pathExecPkgJson = '/otherdir/package.json'
+
+  const process = {
+    pm2_env: {
+      pm_cwd: pmCwdPath,
+      pm_exec_path: pmExecPath
+    }
+  }
+
+  statSyncStub.withArgs(pmCwdPath).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathPkgJson).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pmExecPath).returns({
+    isFile: () => false
+  })
+  statSyncStub.withArgs(pathExecPkgJson).returns({
+    isFile: () => false
   })
 
-  test.test('checkPackageJson returns true if path is file with no package.json in dir', (t) => {
-    const pathToCheck = '/dir/file.js'
-    const pathPkgJson = '/dir/package.json'
-
-    statSyncStub.withArgs(pathToCheck).returns({
-      isFile: () => true
-    })
-    statSyncStub.withArgs(pathPkgJson).returns({
-      isFile: () => false
-    })
-    const result = checkPackageJson(pathToCheck)
-
-    t.notOk(result)
-
-    t.end()
-  })
-
-  test.test(
-    'getTruePath returns pm_cwd path if its good and removes filename from path',
-    async (t) => {
-      const pmCwdPath = '/dir/file.js'
-      const pathPkgJson = '/dir/package.json'
-      const pmExecPath = '/otherdir'
-      const pathExecPkgJson = '/otherdir/package.json'
-
-      const process = {
-        pm2_env: {
-          pm_cwd: pmCwdPath,
-          pm_exec_path: pmExecPath
-        }
-      }
-
-      statSyncStub.withArgs(pmCwdPath).returns({
-        isFile: () => true
-      })
-      statSyncStub.withArgs(pathPkgJson).returns({
-        isFile: () => true
-      })
-      statSyncStub.withArgs(pmExecPath).returns({
-        isFile: () => false
-      })
-      statSyncStub.withArgs(pathExecPkgJson).returns({
-        isFile: () => false
-      })
-      const result = await getTruePath(process)
-
-      t.ok(result)
-      t.equal(result, '/dir')
-
-      t.end()
-    }
-  )
-
-  test.test(
-    'getTruePath returns pm_exec_path is dir w/ package.json and pm_cwd is bad',
-    async (t) => {
-      const pmCwdPath = '/dir'
-      const pathPkgJson = '/dir/package.json'
-      const pmExecPath = '/otherdir'
-      const pathExecPkgJson = '/otherdir/package.json'
-
-      const process = {
-        pm2_env: {
-          pm_cwd: pmCwdPath,
-          pm_exec_path: pmExecPath
-        }
-      }
-
-      statSyncStub.withArgs(pmCwdPath).returns({
-        isFile: () => false
-      })
-      statSyncStub.withArgs(pathPkgJson).returns({
-        isFile: () => false
-      })
-      statSyncStub.withArgs(pmExecPath).returns({
-        isFile: () => false
-      })
-      statSyncStub.withArgs(pathExecPkgJson).returns({
-        isFile: () => true
-      })
-      const result = await getTruePath(process)
-
-      t.ok(result)
-      t.equal(result, '/otherdir')
-
-      t.end()
-    }
-  )
-
-  test.test('getTruePath rejects when pm_exec_path and pm_cwd are bad', async (t) => {
-    const pmCwdPath = '/dir'
-    const pathPkgJson = '/dir/package.json'
-    const pmExecPath = '/otherdir'
-    const pathExecPkgJson = '/otherdir/package.json'
-
-    const process = {
-      pm2_env: {
-        pm_cwd: pmCwdPath,
-        pm_exec_path: pmExecPath
-      }
-    }
-
-    statSyncStub.withArgs(pmCwdPath).returns({
-      isFile: () => false
-    })
-    statSyncStub.withArgs(pathPkgJson).returns({
-      isFile: () => false
-    })
-    statSyncStub.withArgs(pmExecPath).returns({
-      isFile: () => false
-    })
-    statSyncStub.withArgs(pathExecPkgJson).returns({
-      isFile: () => false
-    })
-
-    try {
-      await getTruePath(process)
-    } catch (e) {
-      t.notOk(e)
-    }
-
-    t.end()
-  })
+  await assert.rejects(getTruePath(process))
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

While adding Node 26, I noticed these tests were still using tap. This PR migrates to `node:test`
